### PR TITLE
Bump Go-Go-Golems release train dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/dop251/goja_nodejs v0.0.0-20260212111938-1f56ff5bcf14
 	github.com/go-go-golems/clay v0.4.11
 	github.com/go-go-golems/glazed v1.3.5
-	github.com/go-go-golems/go-go-goja v0.6.0
+	github.com/go-go-golems/go-go-goja v0.7.0
 	github.com/go-go-golems/logcopter v0.1.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/go-go-golems/clay v0.4.11 h1:JTzTvL/6/+FCfknrFwPrHZ8d4LQcHX1yF+S250Jg
 github.com/go-go-golems/clay v0.4.11/go.mod h1:Jl1bKnHCgZ0xklhyQfeAQnJiDxfdrHdJ3YzkS5k411k=
 github.com/go-go-golems/glazed v1.3.5 h1:nMduPxFCocHRI8i2KhyimFuqCovy3CtEktdar0R86sI=
 github.com/go-go-golems/glazed v1.3.5/go.mod h1:Q+GuLpSK6OHfDJBbrA4RFOkpYPw++2jj5FAquem8w8g=
-github.com/go-go-golems/go-go-goja v0.6.0 h1:O2nPhg3j4TzK2zOElnMVcyBIYqrHVfBgXiXmaQ82ntw=
-github.com/go-go-golems/go-go-goja v0.6.0/go.mod h1:h2eI4uVtUFy7UdOmUWVwUgg3iLl3CHpyk3gEbOYvbJc=
+github.com/go-go-golems/go-go-goja v0.7.0 h1:mN92Wq920J0gLL7KvGcSGlcw9mQs6e5cFXh0qPPb4IY=
+github.com/go-go-golems/go-go-goja v0.7.0/go.mod h1:p8zrYdfGjbBNqi3WHfKxjMzQaXIw+QSyJihn0Abs7TM=
 github.com/go-go-golems/logcopter v0.1.0 h1:CGBxAGudhoQOncJ6GEWDJ6c1g5LrU59/ewGlPFKBmdk=
 github.com/go-go-golems/logcopter v0.1.0/go.mod h1:HNCeqsUqxu+Jm5h05YlbN5+KFtK84D5ZnOimvVLyWH4=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=


### PR DESCRIPTION
Bumps Go-Go-Golems dependencies after go-go-goja v0.7.0 and geppetto v0.12.2, then refreshes generated logcopter output where needed.\n\nValidation:\n- make bump-go-go-golems\n- make logcopter-generate\n- make logcopter-check\n- make glazed-lint\n- GOWORK=off go test ./...